### PR TITLE
Fixes condition to query for data on getPageInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Feature
 * Built with Firefox [WebExtensions](https://developer.mozilla.org/en-US/Add-ons/WebExtensions)
 * Add/Update/Delete bookmark from the popup window.
 * Icon changing to show current page has been saved or not.
+* Keyboard shortcut Alt+P to open popup window
 
 Install
 -------

--- a/js/background.js
+++ b/js/background.js
@@ -76,7 +76,7 @@ var getUserInfo = function () {
 // for popup.html to acquire page info
 // if there is no page info at local then get it from server
 var getPageInfo = function (url) {
-    if (!url || (url.indexOf('https://') !== 0 && url.indexOf('http://') !== 0) || localStorage[nopingKey] === 'true') {
+    if (!url || (url.indexOf('https://') !== 0 && url.indexOf('http://') !== 0)) {
         return { url: url, isSaved: false };
     }
     var pageInfo = pages[url];

--- a/manifest.json
+++ b/manifest.json
@@ -40,5 +40,12 @@
     "options_ui": {
         "page": "html/options.html",
         "open_in_tab": true
+    },
+    "commands": {
+        "_execute_browser_action": {
+            "suggested_key": {
+                "default": "Alt+P"
+            }
+        }
     }
 }


### PR DESCRIPTION
When the option "Do not check if page has already been bookmarked" was
enabled, it did not load the necessary information to save the bookmark
when the button was clicked. Instead, it was stuck at "Loading
bookmark...". Removing the condition for this setting on getPageInfo
fixes that.