### PR TITLE
Add page action functionality. Includes toggle in options.html.

### DIFF
--- a/html/options.html
+++ b/html/options.html
@@ -23,6 +23,13 @@
             <span class="checkbox"><input type="checkbox" id="all-private" /></span>
             <label for="all-private">Private checkbox checked by default</label>
         </p>
+        <p>
+            <span class="checkbox"><input type="checkbox" id="no-page-action" /></span>
+            <label for="no-page-action">Do not show icon inside location URL bar</label>
+            <span class="meta">
+                (Restart extension to apply changes)
+            </span>
+        </p>
     </section>
     <script type="text/javascript" src="/js/libs/jquery.min.js"></script>
     <script type="text/javascript" src="/js/common.js"></script>

--- a/js/background.js
+++ b/js/background.js
@@ -353,14 +353,18 @@ browser.tabs.query({ active: true, currentWindow: true }, function (tabs) {
         return;
     }
     console.log("query tab pin state on loaded");
+    attemptPageAction(tab);
     queryPinState({
         url: tab.url,
         ready: function (pageInfo) {
             if (pageInfo && pageInfo.isSaved) {
                 browser.browserAction.setIcon(
                     { path: yesIcon, tabId: tab.id });
+                browser.pageAction.setIcon(
+                    { path: yesIcon, tabId: tab.id });
             } else {
                 browser.browserAction.setIcon({path: noIcon, tabId: tab.id});
+                browser.pageAction.setIcon({path: noIcon, tabId: tab.id});
             }
         }
     });
@@ -375,14 +379,18 @@ browser.tabs.onUpdated.addListener(function (id, changeInfo, tab) {
         if (!pages.hasOwnProperty(url)) {
             console.log("query tab pin state on updated");
             browser.browserAction.setIcon({ path: noIcon, tabId: tab.id });
+            attemptPageAction(tab);
             queryPinState({
                 url: url,
                 ready: function (pageInfo) {
                     if (pageInfo && pageInfo.isSaved) {
                         browser.browserAction.setIcon(
                             { path: yesIcon, tabId: tab.id });
+                        browser.pageAction.setIcon(
+                            { path: yesIcon, tabId: tab.id });
                     } else {
                         browser.browserAction.setIcon({path: noIcon, tabId: tab.id});
+                        browser.pageAction.setIcon({path: noIcon, tabId: tab.id});
                     }
                 }
             });
@@ -390,6 +398,7 @@ browser.tabs.onUpdated.addListener(function (id, changeInfo, tab) {
     }
     console.log("set tab pin state on opening");
     var url = changeInfo.url || tab.url;
+    attemptPageAction(tab);
     if (pages[url] && pages[url].isSaved) {
         browser.browserAction.setIcon({ path: yesIcon, tabId: tab.id });
     }
@@ -404,17 +413,32 @@ browser.tabs.onActivated.addListener(function (activeInfo) {
         var url = tab.url;
         if (!pages.hasOwnProperty(url)) {
             console.log("query tab pin state on actived");
+            attemptPageAction(tab);
             queryPinState({
                 url: url,
                 ready: function (pageInfo) {
                     if (pageInfo && pageInfo.isSaved) {
                         browser.browserAction.setIcon(
                             { path: yesIcon, tabId: tab.id });
+                        browser.pageAction.setIcon(
+                            { path: yesIcon, tabId: tab.id });
                     } else {
                         browser.browserAction.setIcon({path: noIcon, tabId: tab.id});
+                        browser.pageAction.setIcon({path: noIcon, tabId: tab.id});
                     }
                 }
             });
         }
     });
 });
+
+/*
+Attempt to create a page action on this tab.
+Do not show if options checkbox is checked or this is an invalid tab.
+*/
+function attemptPageAction(tab) {
+    browser.pageAction.hide(tab.id);
+    if (localStorage[nopageaction] !== 'true' && (tab.url.indexOf("http://") !== -1 || tab.url.indexOf("https://") !== -1)) {
+        browser.pageAction.show(tab.id);
+    }
+}

--- a/js/common.js
+++ b/js/common.js
@@ -8,6 +8,8 @@ authTokenKey = keyPrefix + '_auth_token',
 nopingKey = keyPrefix + 'np',
 // config in the settings for always check the private checkbox
 allprivateKey = keyPrefix + 'allprivate',
+// config in the settings for disabling page action
+nopageaction = keyPrefix + 'nopageaction',
 
 mainPath = 'https://api.pinboard.in/v1/',
 

--- a/js/options.js
+++ b/js/options.js
@@ -10,4 +10,9 @@ $(function() {
         var value = $(this).is(':checked');
         localStorage[allprivateKey] = value;
     });
+    $('#no-page-action').attr('checked', localStorage[nopageaction] === 'true')
+    .click(function () {
+        var value = $(this).is(':checked');
+        localStorage[nopageaction] = value;
+    });
 });

--- a/manifest.json
+++ b/manifest.json
@@ -37,6 +37,17 @@
         },
         "default_popup": "html/popup.html"
     },
+    "page_action": {
+        "browser_style": true,
+        "default_title": "Pinboard+",
+        "default_icon": {
+            "18": "img/icon-gray-18.png",
+            "32": "img/icon-gray-32.png",
+            "36": "img/icon-gray-36.png",
+            "64": "img/icon-gray-64.png"
+        },
+        "default_popup": "html/popup.html"
+    },
     "options_ui": {
         "page": "html/options.html",
         "open_in_tab": true


### PR DESCRIPTION
This makes a 'page action' for Pinboard+. This is simply an icon in the location URL bar for Pinboard+.

Clicking this icon has identical functionality with the 'browser action' icon.

This icon is optional and can be disabled in the options menu.

![pinboard-firefox-page-action](https://user-images.githubusercontent.com/4945652/32584508-a6dcba2a-c4c6-11e7-8983-c8411a379ead.png)

