### PR TITLE
Fix issue where page action icon is not blue when the page is already bookmarked.

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -162,6 +162,8 @@ var updateSelectedTabExtIcon = function () {
         }
         browser.browserAction.setIcon(
             { path: iconPath, tabId: tab.id });
+        browser.pageAction.setIcon(
+            { path: iconPath, tabId: tab.id });
     });
 };
 
@@ -401,6 +403,7 @@ browser.tabs.onUpdated.addListener(function (id, changeInfo, tab) {
     attemptPageAction(tab);
     if (pages[url] && pages[url].isSaved) {
         browser.browserAction.setIcon({ path: yesIcon, tabId: tab.id });
+        browser.pageAction.setIcon({ path: yesIcon, tabId: tab.id });
     }
 });
 


### PR DESCRIPTION
This change fixes an issue where the page action icon is not blue when the page is already bookmarked.

This can happen when the page was just added as a bookmark or when the browser action icon was just used to add the bookmark.