### PR TITLE
Disable default autocomplete in popup

### DIFF
--- a/html/popup.html
+++ b/html/popup.html
@@ -67,7 +67,7 @@
                 </li>
                 <li>
                     <label class="item-title">Tags</label>
-                    <input id="tag" type="text" autofocus="autofocus" />
+                    <input id="tag" type="text" autofocus="autofocus" autocomplete="off" />
                 </li>
                 <li id="suggest-list" style="display: none;">
                     <label class="item-title">Suggest</label>


### PR DESCRIPTION
In the "Tags" field in the popup, the browser's default auto suggestions cover up the custom suggestions provided by the extension. Since the browser's suggestions are based on historical inputs and not on the user's actual tags, they aren't as good, and this disables it.