### PR TITLE
Filter unwanted tags from suggested tags

### DIFF
--- a/css/options.css
+++ b/css/options.css
@@ -47,3 +47,29 @@ span.checkbox input {
 p {
     margin: 0 0 12px 0;
 }
+
+p.tag-filter{
+    margin-top: 30px;
+}
+
+p.tag-filter label{
+    font-size: 14px;
+}
+
+p.tag-filter textarea{
+    display: block;
+    margin: 10px 0px;
+}
+
+button {
+    background-color: dodgerblue;
+    border: none;
+    color: white;
+    padding: 15px 20px;
+    text-align: center;
+    text-decoration: none;
+    display: inline-block;
+    font-size: 16px;
+    margin: 4px 2px;
+    cursor: pointer;
+}

--- a/html/options.html
+++ b/html/options.html
@@ -30,6 +30,14 @@
                 (Restart extension to apply changes)
             </span>
         </p>
+        <p class="tag-filter">
+            <label for="tag-filter">Exclude these tags from the suggested tags list:</label>
+            <span class="meta">
+                (Separate tags by comma)
+            </span>
+            <textarea id="tag-filter" rows="4" cols="80"></textarea>
+            <button id="tag-filter-save">Save tags filter</button>
+        </p>
     </section>
     <script type="text/javascript" src="/js/libs/jquery.min.js"></script>
     <script type="text/javascript" src="/js/common.js"></script>

--- a/js/background.js
+++ b/js/background.js
@@ -298,7 +298,6 @@ var getSuggest = function (url) {
                 }
             });
             suggests = filterSuggests(suggests);
-            console.log("Suggested: ", suggests);
             browser.runtime.sendMessage({
                 type: "render-suggests",
                 data: suggests
@@ -313,8 +312,6 @@ var filterSuggests = function(suggestedTags){
         filteredTags = filteredTags.toLowerCase().replace(/\s/g,'').split(',');
     }
     const lcSuggestedTags = suggestedTags.map(function(tag){ return tag.toLowerCase();});
-    console.log("Filters: ", filteredTags)
-    console.log("Suggested Tags: ", suggestedTags)
     $.each(filteredTags, function(index, tag){
         const suggestedIdx = lcSuggestedTags.indexOf(tag);
         if(suggestedIdx > -1){
@@ -322,7 +319,6 @@ var filterSuggests = function(suggestedTags){
             lcSuggestedTags.splice(suggestedIdx,1);
         }
     });
-    console.log("Filtered Tags: ", suggestedTags)
     return suggestedTags;
 }
 

--- a/js/background.js
+++ b/js/background.js
@@ -297,6 +297,8 @@ var getSuggest = function (url) {
                     suggests.push(tag);
                 }
             });
+            suggests = filterSuggests(suggests);
+            console.log("Suggested: ", suggests);
             browser.runtime.sendMessage({
                 type: "render-suggests",
                 data: suggests
@@ -304,6 +306,25 @@ var getSuggest = function (url) {
         });
     }
 };
+
+var filterSuggests = function(suggestedTags){
+    let filteredTags = localStorage[tagfilterkey];
+    if(filteredTags && filteredTags.replace(/\s/g,'').length > 0){
+        filteredTags = filteredTags.toLowerCase().replace(/\s/g,'').split(',');
+    }
+    const lcSuggestedTags = suggestedTags.map(function(tag){ return tag.toLowerCase();});
+    console.log("Filters: ", filteredTags)
+    console.log("Suggested Tags: ", suggestedTags)
+    $.each(filteredTags, function(index, tag){
+        const suggestedIdx = lcSuggestedTags.indexOf(tag);
+        if(suggestedIdx > -1){
+            suggestedTags.splice(suggestedIdx,1);
+            lcSuggestedTags.splice(suggestedIdx,1);
+        }
+    });
+    console.log("Filtered Tags: ", suggestedTags)
+    return suggestedTags;
+}
 
 var _tags = [], _tagsWithCount = {};
 // acquire all user tags from server refresh _tags

--- a/js/common.js
+++ b/js/common.js
@@ -10,6 +10,8 @@ nopingKey = keyPrefix + 'np',
 allprivateKey = keyPrefix + 'allprivate',
 // config in the settings for disabling page action
 nopageaction = keyPrefix + 'nopageaction',
+//config in settings for filtering suggested tags
+tagfilterkey = keyPrefix + 'tagfilter',
 
 mainPath = 'https://api.pinboard.in/v1/',
 

--- a/js/options.js
+++ b/js/options.js
@@ -15,4 +15,10 @@ $(function() {
         var value = $(this).is(':checked');
         localStorage[nopageaction] = value;
     });
+    $('#tag-filter').val(localStorage[tagfilterkey])
+    $('#tag-filter-save').click(function () {
+        var value = $('#tag-filter').val();
+        console.log("Value to save: ", value);
+        localStorage[tagfilterkey] = value;
+    });
 });

--- a/js/options.js
+++ b/js/options.js
@@ -18,7 +18,6 @@ $(function() {
     $('#tag-filter').val(localStorage[tagfilterkey])
     $('#tag-filter-save').click(function () {
         var value = $('#tag-filter').val();
-        console.log("Value to save: ", value);
         localStorage[tagfilterkey] = value;
     });
 });

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Pinboard+",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "A better firefox extension for Pinboard (http://pinboard.in).",
     "homepage_url": "https://github.com/lostsnow/pinboard-firefox",
     "icons": {


### PR DESCRIPTION
I love the "Add All" for adding tags with Pinboard+; however, tags are often suggested that aren't useful (IFTTT, popular, etc).  This feature allows a user to specify a comma-separated list of tags to ignore in suggestions.  Ignored tags will not be added to the "Suggest" tags list in the pinboard entry dialog.