### PR TITLE
Open Pinboard+ when icon removed from toolbar

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -61,7 +61,7 @@
         "open_in_tab": true
     },
     "commands": {
-        "_execute_browser_action": {
+        "_execute_page_action": {
             "suggested_key": {
                 "default": "Alt+P"
             }


### PR DESCRIPTION
Fixes #28 